### PR TITLE
Expose opponent in chat JSON

### DIFF
--- a/app/views/round/player.scala
+++ b/app/views/round/player.scala
@@ -29,7 +29,8 @@ def player(
           withNoteAge = ctx.isAuth.option(pov.game.secondsSinceCreation),
           public = false,
           resourceId = lila.chat.Chat.ResourceId(s"game/${c.chat.id}"),
-          voiceChat = ctx.canVoiceChat
+          voiceChat = ctx.canVoiceChat,
+          opponentId = pov.opponent.userId
         )
       case Right((c, res)) =>
         views.chat.json(
@@ -38,7 +39,8 @@ def player(
           name = trans.site.chatRoom.txt(),
           timeout = c.timeout,
           public = true,
-          resourceId = res
+          resourceId = res,
+          opponentId = pov.opponent.userId
         )
 
   val opponentNameOrZen = if ctx.pref.isZen || ctx.pref.isZenAuto then "ZEN" else playerText(pov.opponent)

--- a/app/views/round/watcher.scala
+++ b/app/views/round/watcher.scala
@@ -25,7 +25,8 @@ def watcher(
       withNoteAge = ctx.isAuth.option(pov.game.secondsSinceCreation),
       public = true,
       resourceId = lila.chat.Chat.ResourceId(s"game/${c.chat.id}"),
-      voiceChat = ctx.canVoiceChat
+      voiceChat = ctx.canVoiceChat,
+      opponentId = pov.opponent.userId
     )
 
   ui.RoundPage(pov.game.variant, s"${gameVsText(pov.game, withRatings = ctx.pref.showRatings)} • spectator")

--- a/modules/chat/src/main/ChatUi.scala
+++ b/modules/chat/src/main/ChatUi.scala
@@ -32,7 +32,8 @@ object ChatUi:
       withNoteAge: Option[Int] = None,
       writeable: Boolean = true,
       localMod: Boolean = false,
-      voiceChat: Boolean = false
+      voiceChat: Boolean = false,
+      opponentId: Option[UserId] = None
   )(using Context): JsObject =
     json(
       chat.chat,
@@ -45,7 +46,8 @@ object ChatUi:
       resourceId = resourceId,
       restricted = chat.restricted,
       localMod = localMod,
-      voiceChat = voiceChat
+      voiceChat = voiceChat,
+      opponentId = opponentId
     )
 
   def json(
@@ -61,7 +63,8 @@ object ChatUi:
       localMod: Boolean = false,
       broadcastMod: Boolean = false,
       voiceChat: Boolean = false,
-      hostIds: List[UserId] = Nil
+      hostIds: List[UserId] = Nil,
+      opponentId: Option[UserId] = None
   )(using ctx: Context): JsObject =
     val noteId = (withNoteAge.isDefined && ctx.noBlind).option(chat.id.value.take(8))
     if ctx.kid.yes then
@@ -83,7 +86,10 @@ object ChatUi:
             .add("userId" -> ctx.userId)
             .add("loginRequired" -> chat.loginRequired)
             .add("restricted" -> restricted)
-            .add("voiceChat" -> (voiceChat && ctx.isAuth)),
+            .add("voiceChat" -> (voiceChat && ctx.isAuth))
+            .add(
+              "opponent" -> opponentId.map(id => Json.obj("user" -> Json.obj("id" -> id.value)))
+            ),
           "writeable" -> writeable,
           "public" -> public,
           "permissions" -> Json


### PR DESCRIPTION
## Summary
- allow chat JSON to include optional opponent user id
- pass opponent user id from round player and watcher views

## Testing
- `sbt test` *(fails: command not found)*
- `./ui/build` *(fails: Nodejs v24.1.0 or later is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e6c9ec488328b2a2d3bc672b6c5e