### PR TITLE
scope chat input per opponent

### DIFF
--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -108,7 +108,12 @@ function prependChatInput(chatInput: HTMLInputElement, prefix: string): void {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
-  const storage = tempStorage.make('chat.input');
+  const oppId = ctrl.opts.data.opponent?.user?.id ?? 'anon';
+  const key = `chat.input.${oppId}`;
+  Object.keys(sessionStorage)
+    .filter(k => k.startsWith('chat.input.') && k !== key)
+    .forEach(k => sessionStorage.removeItem(k));
+  const storage = tempStorage.make(key);
   const previousText = storage.get();
   if (previousText) {
     chatEl.value = previousText;

--- a/ui/lib/src/chat/interfaces.ts
+++ b/ui/lib/src/chat/interfaces.ts
@@ -41,6 +41,7 @@ export interface ChatData {
   restricted: boolean;
   voiceChat: boolean;
   hostIds?: string[];
+  opponent?: { user?: { id?: string } };
 }
 
 export interface Line {


### PR DESCRIPTION
## Summary
- store chat input per opponent to avoid crosstalk
- add optional opponent info to chat data

## Testing
- `pnpm lint`
- `pnpm test`
- `./ui/build` *(fails: Nodejs v24.1.0 or later is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b47f226c8328bbcc6b85011350cb