### PR TITLE
Chat message saved locally: simplify separation by opponent

### DIFF
--- a/modules/chat/src/main/ChatUi.scala
+++ b/modules/chat/src/main/ChatUi.scala
@@ -88,7 +88,7 @@ object ChatUi:
             .add("restricted" -> restricted)
             .add("voiceChat" -> (voiceChat && ctx.isAuth))
             .add(
-              "opponent" -> opponentId.map(id => Json.obj("user" -> Json.obj("id" -> id.value)))
+              "opponentId" -> opponentId
             ),
           "writeable" -> writeable,
           "public" -> public,

--- a/ui/lib/src/chat/discussion.ts
+++ b/ui/lib/src/chat/discussion.ts
@@ -108,12 +108,7 @@ function prependChatInput(chatInput: HTMLInputElement, prefix: string): void {
 let mouchListener: EventListener;
 
 const setupHooks = (ctrl: ChatCtrl, chatEl: HTMLInputElement) => {
-  const oppId = ctrl.opts.data.opponent?.user?.id ?? 'anon';
-  const key = `chat.input.${oppId}`;
-  Object.keys(sessionStorage)
-    .filter(k => k.startsWith('chat.input.') && k !== key)
-    .forEach(k => sessionStorage.removeItem(k));
-  const storage = tempStorage.make(key);
+  const storage = tempStorage.make(`chat.input.${ctrl.opts.data.opponentId}`);
   const previousText = storage.get();
   if (previousText) {
     chatEl.value = previousText;

--- a/ui/lib/src/chat/interfaces.ts
+++ b/ui/lib/src/chat/interfaces.ts
@@ -41,7 +41,7 @@ export interface ChatData {
   restricted: boolean;
   voiceChat: boolean;
   hostIds?: string[];
-  opponent?: { user?: { id?: string } };
+  opponentId?: string;
 }
 
 export interface Line {


### PR DESCRIPTION
It seems surprising than the opponent info was not sent already. If we think it's worth enough to send info can be kept that way, otherwise an idea would be to get the info from `Line`.

Also considering the message is saved in temp storage I don't think it's worth troubling ourselves with deletion.